### PR TITLE
fix: Add Amsterdam BAL support to engine API

### DIFF
--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
 )
 
 var _ = (*executableDataMarshaling)(nil)
@@ -34,6 +35,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		Withdrawals      []*types.Withdrawal     `json:"withdrawals"`
 		BlobGasUsed      *hexutil.Uint64         `json:"blobGasUsed"`
 		ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
+		BlockAccessList  *bal.BlockAccessList    `json:"blockAccessList"`
 		ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 	}
 	var enc ExecutableData
@@ -59,6 +61,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	enc.Withdrawals = e.Withdrawals
 	enc.BlobGasUsed = (*hexutil.Uint64)(e.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(e.ExcessBlobGas)
+	enc.BlockAccessList = e.BlockAccessList
 	enc.ExecutionWitness = e.ExecutionWitness
 	return json.Marshal(&enc)
 }
@@ -83,6 +86,7 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 		Withdrawals      []*types.Withdrawal     `json:"withdrawals"`
 		BlobGasUsed      *hexutil.Uint64         `json:"blobGasUsed"`
 		ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
+		BlockAccessList  *bal.BlockAccessList    `json:"blockAccessList"`
 		ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 	}
 	var dec ExecutableData
@@ -156,6 +160,9 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ExcessBlobGas != nil {
 		e.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.BlockAccessList != nil {
+		e.BlockAccessList = dec.BlockAccessList
 	}
 	if dec.ExecutionWitness != nil {
 		e.ExecutionWitness = dec.ExecutionWitness

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -19,6 +19,8 @@ package engine
 import (
 	"fmt"
 	"github.com/ethereum/go-ethereum/core/types/bal"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 	"math/big"
 	"slices"
 
@@ -276,32 +278,38 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		requestsHash = &h
 	}
 
+	var blockAccessListHash *common.Hash
 	body := types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals}
 	if data.BlockAccessList != nil {
 		body.AccessList = data.BlockAccessList
+		// Calculate the hash of the RLP-encoded BAL
+		rlpBytes, _ := rlp.EncodeToBytes(data.BlockAccessList)
+		h := crypto.Keccak256Hash(rlpBytes)
+		blockAccessListHash = &h
 	}
 
 	header := &types.Header{
-		ParentHash:       data.ParentHash,
-		UncleHash:        types.EmptyUncleHash,
-		Coinbase:         data.FeeRecipient,
-		Root:             data.StateRoot,
-		TxHash:           types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil)),
-		ReceiptHash:      data.ReceiptsRoot,
-		Bloom:            types.BytesToBloom(data.LogsBloom),
-		Difficulty:       common.Big0,
-		Number:           new(big.Int).SetUint64(data.Number),
-		GasLimit:         data.GasLimit,
-		GasUsed:          data.GasUsed,
-		Time:             data.Timestamp,
-		BaseFee:          data.BaseFeePerGas,
-		Extra:            data.ExtraData,
-		MixDigest:        data.Random,
-		WithdrawalsHash:  withdrawalsRoot,
-		ExcessBlobGas:    data.ExcessBlobGas,
-		BlobGasUsed:      data.BlobGasUsed,
-		ParentBeaconRoot: beaconRoot,
-		RequestsHash:     requestsHash,
+		ParentHash:          data.ParentHash,
+		UncleHash:           types.EmptyUncleHash,
+		Coinbase:            data.FeeRecipient,
+		Root:                data.StateRoot,
+		TxHash:              types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil)),
+		ReceiptHash:         data.ReceiptsRoot,
+		Bloom:               types.BytesToBloom(data.LogsBloom),
+		Difficulty:          common.Big0,
+		Number:              new(big.Int).SetUint64(data.Number),
+		GasLimit:            data.GasLimit,
+		GasUsed:             data.GasUsed,
+		Time:                data.Timestamp,
+		BaseFee:             data.BaseFeePerGas,
+		Extra:               data.ExtraData,
+		MixDigest:           data.Random,
+		WithdrawalsHash:     withdrawalsRoot,
+		ExcessBlobGas:       data.ExcessBlobGas,
+		BlobGasUsed:         data.BlobGasUsed,
+		ParentBeaconRoot:    beaconRoot,
+		RequestsHash:        requestsHash,
+		BlockAccessListHash: blockAccessListHash,
 	}
 	return types.NewBlockWithHeader(header).
 			WithBody(body).

--- a/core/types/bal/bal_encoding.go
+++ b/core/types/bal/bal_encoding.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -340,4 +341,32 @@ type ContractCode []byte
 func (c *ContractCode) MarshalJSON() ([]byte, error) {
 	hexStr := fmt.Sprintf("%x", *c)
 	return json.Marshal(hexStr)
+}
+
+// UnmarshalJSON implements json.Unmarshaler to decode from RLP hex bytes
+func (b *BlockAccessList) UnmarshalJSON(input []byte) error {
+	// Handle both hex string and object formats
+	var hexBytes hexutil.Bytes
+	if err := json.Unmarshal(input, &hexBytes); err == nil {
+		// It's a hex string, decode from RLP
+		return rlp.DecodeBytes(hexBytes, b)
+	}
+	
+	// Otherwise try to unmarshal as structured JSON
+	var tmp []AccountAccess
+	if err := json.Unmarshal(input, &tmp); err != nil {
+		return err
+	}
+	*b = BlockAccessList(tmp)
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler to encode as RLP hex bytes
+func (b BlockAccessList) MarshalJSON() ([]byte, error) {
+	// Encode to RLP then to hex
+	rlpBytes, err := rlp.EncodeToBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(hexutil.Bytes(rlpBytes))
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -542,6 +542,7 @@ func (b *Block) WithWitness(witness *ExecutionWitness) *Block {
 		transactions: b.transactions,
 		uncles:       b.uncles,
 		withdrawals:  b.withdrawals,
+		accessList:   b.accessList,
 		witness:      witness,
 	}
 }

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -249,8 +249,8 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV3(update engine.ForkchoiceStateV1, pa
 			return engine.STATUS_INVALID, attributesErr("missing withdrawals")
 		case params.BeaconRoot == nil:
 			return engine.STATUS_INVALID, attributesErr("missing beacon root")
-		case !api.checkFork(params.Timestamp, forks.Cancun, forks.Prague, forks.Osaka):
-			return engine.STATUS_INVALID, unsupportedForkErr("fcuV3 must only be called for cancun or prague payloads")
+		case !api.checkFork(params.Timestamp, forks.Cancun, forks.Prague, forks.Osaka, forks.Amsterdam):
+			return engine.STATUS_INVALID, unsupportedForkErr("fcuV3 must only be called for cancun, prague, osaka or amsterdam payloads")
 		}
 	}
 	// TODO(matt): the spec requires that fcu is applied when called on a valid


### PR DESCRIPTION
I used AI to help debug the remaining issues with `consume engine` (free to scrap this 😅). I ended up getting this passing. By no means does this need to be merged as is but if you find it helpful, feel free to merge and change anything you need here. The goal was just to investigate the remaining issues.

One thing to check out here is how the `UnmarshalJSON` implementation is working. This seemed like the least complex approach but it also may not be the approach that geth prefers to take here.

The invalid tests are failing but that's because they are expecting `BlockException.INCORRECT_BLOCK_FORMAT` and we instead get an invalid blockhash check from geth (a different exception but still an exception). I think this is something we can iron out as it's just an exception mapper issue but it would work otherwise.