### PR TITLE
Use PayloadV4 after Amsterdam fork

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -39,6 +39,7 @@ var (
 	PayloadV1 PayloadVersion = 0x1
 	PayloadV2 PayloadVersion = 0x2
 	PayloadV3 PayloadVersion = 0x3
+	PayloadV4 PayloadVersion = 0x4
 )
 
 //go:generate go run github.com/fjl/gencodec -type PayloadAttributes -field-override payloadAttributesMarshaling -out gen_blockparams.go

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -253,6 +253,10 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV3(update engine.ForkchoiceStateV1, pa
 		case !api.checkFork(params.Timestamp, forks.Cancun, forks.Prague, forks.Osaka, forks.Amsterdam):
 			return engine.STATUS_INVALID, unsupportedForkErr("fcuV3 must only be called for cancun, prague, osaka or amsterdam payloads")
 		}
+
+		if api.checkFork(params.Timestamp, forks.Amsterdam) {
+			return api.forkchoiceUpdated(update, params, engine.PayloadV4, false)
+		}
 	}
 	// TODO(matt): the spec requires that fcu is applied when called on a valid
 	// hash, even if params are wrong. To do this we need to split up
@@ -487,7 +491,7 @@ func (api *ConsensusAPI) GetPayloadV5(payloadID engine.PayloadID) (*engine.Execu
 
 // GetPayloadV6 returns a cached payload by id.
 func (api *ConsensusAPI) GetPayloadV6(payloadID engine.PayloadID) (*engine.ExecutionPayloadEnvelope, error) {
-	if !payloadID.Is(engine.PayloadV3) {
+	if !payloadID.Is(engine.PayloadV4) {
 		return nil, engine.UnsupportedFork
 	}
 	return api.getPayload(payloadID, false)

--- a/params/config.go
+++ b/params/config.go
@@ -1031,6 +1031,8 @@ func (c *ChainConfig) ActiveSystemContracts(time uint64) map[string]common.Addre
 // the fork isn't defined or isn't a time-based fork.
 func (c *ChainConfig) Timestamp(fork forks.Fork) *uint64 {
 	switch {
+	case fork == forks.Amsterdam:
+		return c.AmsterdamTime
 	case fork == forks.Osaka:
 		return c.OsakaTime
 	case fork == forks.Prague:

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -73,4 +73,5 @@ var forkToString = map[Fork]string{
 	Cancun:           "Cancun",
 	Prague:           "Prague",
 	Osaka:            "Osaka",
+	Amsterdam:        "Amsterdam",
 }


### PR DESCRIPTION
This PR uses PayloadV4 after Amsterdam fork, following the execution spec. ~~Note that merging this PR won't make the interop with Lodestar work. Lodestar seems to set `params.timestamp` with parent block's time, which make Geth think it's in Osaka at the first slot of Amsterdam.~~ I was mistaken about this. The first Gloas block won't have BALs, which would be fine. Current issue is Geth not returning BALs, Lodestar is okay.

Feel free to cherry pick whatever needed.